### PR TITLE
converted struct to class, add DType array, and cleanup

### DIFF
--- a/core/include/dtypes.hpp
+++ b/core/include/dtypes.hpp
@@ -1,6 +1,8 @@
 #ifndef DTYPES_HPP
 #define DTYPES_HPP
 
+#include <cstddef>
+
 typedef enum DType {
     UINT8,
     UINT16,
@@ -12,15 +14,29 @@ typedef enum DType {
     INT64,
     FLOAT32,
     FLOAT64
-};
+} DType;
 
-struct DTypeDesc {
+class DTypeDesc {
+public:
     const char *name; 
     DType type;
     size_t typeSize;
     size_t alignment;
-}
+};
 
-#endif 
+static DTypeDesc dTypeDesc[] = {
+    {"uint8_t",  UINT8,   1, 0},
+    {"uint16_t", UINT16,  2, 0},
+    {"uint32_t", UINT32,  4, 0},
+    {"uint64_t", UINT64,  8, 0},
+    {"int8_t",   INT8,    1, 0},
+    {"int16_t",  INT16,   2, 0},
+    {"int32_t",  INT32,   4, 0},
+    {"int64_t",  INT64,   8, 0},
+    {"float",    FLOAT32, 4, 0},
+    {"double",   FLOAT64, 8, 0}
+};
+
+#endif // DTYPES_HPP
 
 

--- a/core/include/ndimarray.hpp
+++ b/core/include/ndimarray.hpp
@@ -1,7 +1,12 @@
 #ifndef NDIMARRAY_HPP
 #define NDIMARRAY_HPP
 
-struct NDimArray {
+#include <cstdint>
+
+#include "dtypes.hpp"
+
+class NDimArray {
+public:
     int ndim;
     int64_t* shape;
     DTypeDesc *desc;
@@ -10,4 +15,4 @@ struct NDimArray {
     int flags;
 };
 
-#endif 
+#endif // NDIMARRAY_HPP


### PR DESCRIPTION
Converted struct to class, add DType array, and cleanup

- Changed DTypeDesc from struct to class 
- Completed the dType[] array with names and sizes for mapping
- Applied small fixes to enum definitions and formatting
